### PR TITLE
Enable specific users to have admin powers to delete any poll

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model User {
   worldID                String       @unique
   name                   String?
   profilePicture         String?
+  isAdmin                Boolean      @default(false)
   pollsCreatedCount      Int          @default(0)
   pollsParticipatedCount Int          @default(0)
   createdAt              DateTime     @default(now())

--- a/src/poll/poll.service.ts
+++ b/src/poll/poll.service.ts
@@ -550,7 +550,7 @@ export class PollService {
   async deletePoll(pollId: number, worldID: string) {
     const user = await this.databaseService.user.findUnique({
       where: { worldID },
-      select: { id: true },
+      select: { id: true, isAdmin: true },
     })
     if (!user) {
       throw new UserNotFoundException()
@@ -561,7 +561,8 @@ export class PollService {
     if (!poll) {
       throw new PollNotFoundException()
     }
-    if (poll.authorUserId !== user.id) {
+    // Allow deletion if user is admin or if user is the poll author
+    if (!user.isAdmin && poll.authorUserId !== user.id) {
       throw new UnauthorizedActionException()
     }
 

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -73,7 +73,6 @@ export class UserController {
   }
 
   @Get('listAdmins')
-  @Public()
   async listAdmins(): Promise<string[]> {
     return await this.userService.listAdmins()
   }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -71,4 +71,10 @@ export class UserController {
   async getUserCount(@Query() query: GetCountDto): Promise<number> {
     return await this.userService.getUserCount(query)
   }
+
+  @Get('listAdmins')
+  @Public()
+  async listAdmins(): Promise<string[]> {
+    return await this.userService.listAdmins()
+  }
 }

--- a/src/user/user.dto.ts
+++ b/src/user/user.dto.ts
@@ -40,6 +40,10 @@ export class UserDataResponseDto {
   @IsString()
   @IsOptional()
   name?: string | null
+
+  @IsBoolean()
+  @IsNotEmpty()
+  isAdmin: boolean
 }
 
 export class GetUserActivitiesDto {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -97,6 +97,7 @@ export class UserService {
         worldID: true,
         name: true,
         profilePicture: true,
+        isAdmin: true,
         pollsCreatedCount: true,
         pollsParticipatedCount: true,
       },
@@ -110,6 +111,7 @@ export class UserService {
       worldID: user.worldID,
       worldProfilePic: user.profilePicture,
       name: user.name,
+      isAdmin: user.isAdmin,
     }
   }
 
@@ -455,5 +457,13 @@ export class UserService {
     }
 
     return await this.databaseService.user.count({ where })
+  }
+
+  async listAdmins(): Promise<string[]> {
+    const admins = await this.databaseService.user.findMany({
+      where: { isAdmin: true },
+      select: { worldID: true },
+    })
+    return admins.map(admin => admin.worldID)
   }
 }


### PR DESCRIPTION
* #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an admin flag to user profiles, allowing users to have administrative privileges.
  - Introduced a new endpoint to list all admin users.
- **Improvements**
  - Users with admin privileges can now delete any poll, not just their own.
  - User data responses now include information about admin status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->